### PR TITLE
GitHub Actions workflow to build HTML documentation and deploy to GitHub Pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,4 +14,12 @@ jobs:
         run: whoami
       - name: Is Conda installed?
         run: conda info
+      # Miniconda is pre-installed in Ubuntu 20.04 runner
+      # https://github.com/actions/virtual-environments/blob/ubuntu20/20220330.0/images/linux/Ubuntu2004-Readme.md
+      - name: Create Conda environment
+        run: conda env create --file environment.yml
+      - name: Activate Conda environment
+        run: conda activate HPC-community-docs-env
+      - name: Check sphinx-build
+        run: sphinx-build --version
         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,8 +18,7 @@ jobs:
       # https://github.com/actions/virtual-environments/blob/ubuntu20/20220330.0/images/linux/Ubuntu2004-Readme.md
       - name: Create Conda environment
         run: conda env create --file environment.yml
-      - name: Activate Conda environment
-        run: conda activate HPC-community-docs-env
+      # Use conda run to run commands in an environment. Each job step runs in a
+      # separate process, so cannot use conda activate to work in an environment
       - name: Check sphinx-build
-        run: sphinx-build --version
-        
+        run: conda run --name HPC-community-docs-env -- sphinx-build --version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,6 +66,8 @@ jobs:
           path: _built-html-docs
       - name: Create .nojekyll
         run: touch ${{ steps.download.outputs.download-path }}/.nojekyll
+      - name: Copy humans.txt for this commit
+        run: cp -v -n humans.txt ${{ steps.download.outputs.download-path }}/
       - name: Display contents of HTML documentation directory
         run: ls -R ${{ steps.download.outputs.download-path }}
       - name: Deploy to gh-pages branch

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,10 @@
+name: actions-testing
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Print current directory
+        run: pwd
+        

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,4 +37,18 @@ jobs:
         with:
           name: built-html-docs
           path: build/html/
-
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Download built HTML documentation artifact
+        id: download-built-html-docs
+        uses: actions/download-artifact@v3
+        with:
+          name: built-html-docs
+          path: built-html-docs
+      - name: Display contents of HTML documentation directory
+        run: ls -R ${{ steps.download-built-html-docs.outputs.download-path }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,9 @@ jobs:
         run: ${{ env.CONDA_RUN }} sphinx-build --version
       - name: Build the documentation
         run: ${{ env.CONDA_RUN }} sphinx-build -M html source build
+      # Uploaded artifacts are dynamically zipped when accessed through GitHub UI
+      # so we do not need to zip them beforehand (this would "double zip" the result)
+      # https://github.com/marketplace/actions/upload-a-build-artifact#zipped-artifact-downloads
       - name: Upload built HTML documentation artifact
         if: success()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,18 +59,20 @@ jobs:
           echo '${{ github.repository}}'
           echo '${{ github.ref }}'
       - name: Download built HTML documentation artifact
-        id: download-built-html-docs
+        id: download
         uses: actions/download-artifact@v3
         with:
           name: built-html-docs
-          path: built-html-docs
+          path: _built-html-docs
+      - name: Create .nojekyll
+        run: touch ${{ steps.download.outputs.download-path }}/.nojekyll
       - name: Display contents of HTML documentation directory
-        run: ls -R ${{ steps.download-built-html-docs.outputs.download-path }}
+        run: ls -R ${{ steps.download.outputs.download-path }}
       - name: Deploy to gh-pages branch
         uses: JamesIves/github-pages-deploy-action@v4.3.0
         with:
           branch: gh-pages
-          folder: built-html-docs
+          folder: ${{ steps.download.outputs.download-path }}
           # TODO Limit access of workflow/job through GITHUB_TOKEN to only 
           # necessary permissions
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,10 +37,10 @@ jobs:
     needs: [build]
     permissions:
       contents: write
-    # TODO Deployment should only happen on main branch of official repository
-    # if: >
-    #   github.repository == 'ACRC/HPC-community-docs' &&
-    #   github.ref == 'refs/heads/main'
+    # Deployment should only happen on main branch of official repository
+    if: >
+      github.repository == 'ACRC/HPC-community-docs' &&
+      github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,5 @@
 name: actions-testing
 on: [push]
-
-
-
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,10 +3,15 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v3
       - name: Print current directory
         run: pwd
+      - name: Print user information
+        run: whoami
       - name: Deliberately fail
         run: exit 1
         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,9 @@
-name: actions-testing
+name: Build and deploy HTML documentation
 on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions: {}
     defaults:
       run:
         shell: bash
@@ -33,7 +34,8 @@ jobs:
           path: build/html/
 
   deploy:
-    needs: build
+    needs: [build]
+    permissions: {}
     # TODO Deployment should only happen on main branch of official repository
     # if: >
     #   github.repository == 'ACRC/HPC-community-docs' &&

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,16 @@
 name: actions-testing
 on: [push]
+
+
+
 jobs:
   build:
     runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash
+    env:
+      CONDA_RUN: conda run --name HPC-community-docs-env 
     steps:
       - uses: actions/checkout@v3
       - name: Print current directory
@@ -21,4 +26,6 @@ jobs:
       # Use conda run to run commands in an environment. Each job step runs in a
       # separate process, so cannot use conda activate to work in an environment
       - name: Check sphinx-build
-        run: conda run --name HPC-community-docs-env sphinx-build --version
+        run: ${CONDA_RUN} sphinx-build --version
+      - name: Build the documentation
+        run: ${CONDA_RUN} sphinx-build -M html source build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,8 @@ jobs:
 
   deploy:
     needs: [build]
-    permissions: {}
+    permissions:
+      contents: write
     # TODO Deployment should only happen on main branch of official repository
     # if: >
     #   github.repository == 'ACRC/HPC-community-docs' &&

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,6 @@ jobs:
       # Use conda run to run commands in an environment. Each job step runs in a
       # separate process, so cannot use conda activate to work in an environment
       - name: Check sphinx-build
-        run: ${CONDA_RUN} sphinx-build --version
+        run: ${{ env.CONDA_RUN }} sphinx-build --version
       - name: Build the documentation
-        run: ${CONDA_RUN} sphinx-build -M html source build
+        run: ${{ env.CONDA_RUN }} sphinx-build -M html source build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,9 +39,13 @@ jobs:
           path: build/html/
   deploy:
     needs: build
+    # TODO Change to restrict to ACRC:main for actions used in production
     # if: >
     #   github.repository == 'ACRC/HPC-community-docs' &&
     #   github.ref == 'refs/heads/main'
+    if: >
+      github.repository == 'jcwomack/HPC-community-docs' &&
+      github.ref == 'refs/heads/prototype/gh-actions'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
   deploy:
     needs: [build]
     permissions:
-      contents: read
+      contents: write
     # TODO Deployment should only happen on main branch of official repository
     # if: >
     #   github.repository == 'ACRC/HPC-community-docs' &&

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,10 @@ jobs:
       CONDA_RUN: conda run --name HPC-community-docs-env 
     steps:
       - uses: actions/checkout@v3
-      - name: Print current directory
-        run: pwd
+      - name: Print current directory and github.workspace
+        run: |
+          pwd
+          echo ${{ github.workspace }}
       - name: Print user information
         run: whoami
       - name: Is Conda installed?

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,3 +28,10 @@ jobs:
         run: ${{ env.CONDA_RUN }} sphinx-build --version
       - name: Build the documentation
         run: ${{ env.CONDA_RUN }} sphinx-build -M html source build
+      - name: Upload built HTML documentation artifact
+        if: success()
+        uses: actions/upload-artifact@v3
+        with:
+          name: built-html-docs
+          path: build/html/
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,4 +7,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: Print current directory
         run: pwd
+      - name: Deliberately fail
+        run: exit 1
         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,6 @@ jobs:
         run: pwd
       - name: Print user information
         run: whoami
-      - name: Deliberately fail
-        run: exit 1
+      - name: Is Conda installed?
+        run: conda info
         

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4.3.0
         with:
           branch: gh-pages
-          folder: build/html/
+          folder: built-html-docs
           # TODO Limit access of workflow/job through GITHUB_TOKEN to only 
           # necessary permissions
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,9 @@ jobs:
       run:
         shell: bash
     steps:
+      # actions/checkout required by JamesIves/github-pages-depoy-action
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Get github.repository and github.ref values
         run: |
           echo '${{ github.repository}}'
@@ -63,3 +66,11 @@ jobs:
           path: built-html-docs
       - name: Display contents of HTML documentation directory
         run: ls -R ${{ steps.download-built-html-docs.outputs.download-path }}
+      - name: Deploy to gh-pages branch
+        uses: JamesIves/github-pages-deploy-action@v4.3.0
+        with:
+          branch: gh-pages
+          folder: build/html/
+          # TODO Limit access of workflow/job through GITHUB_TOKEN to only 
+          # necessary permissions
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,4 +21,4 @@ jobs:
       # Use conda run to run commands in an environment. Each job step runs in a
       # separate process, so cannot use conda activate to work in an environment
       - name: Check sphinx-build
-        run: conda run --name HPC-community-docs-env -- sphinx-build --version
+        run: conda run --name HPC-community-docs-env sphinx-build --version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
   deploy:
     needs: [build]
     permissions:
-      contents: write
+      contents: read
     # TODO Deployment should only happen on main branch of official repository
     # if: >
     #   github.repository == 'ACRC/HPC-community-docs' &&

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,9 @@ jobs:
           path: build/html/
   deploy:
     needs: build
+    if: >
+      github.repository == 'ACRC/HPC-community-docs' &&
+      github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,14 +39,18 @@ jobs:
           path: build/html/
   deploy:
     needs: build
-    if: >
-      github.repository == 'ACRC/HPC-community-docs' &&
-      github.ref == 'refs/heads/main'
+    # if: >
+    #   github.repository == 'ACRC/HPC-community-docs' &&
+    #   github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash
     steps:
+      - name: Get github.repository and github.ref values
+        run: |
+          echo '${{ github.repository}}'
+          echo '${{ github.ref }}'
       - name: Download built HTML documentation artifact
         id: download-built-html-docs
         uses: actions/download-artifact@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,27 +7,21 @@ jobs:
       run:
         shell: bash
     env:
+      # Use conda run to run commands in an environment. Each job step runs in a
+      # separate process, so cannot use conda activate to work in an environment
       CONDA_RUN: conda run --name HPC-community-docs-env 
     steps:
-      - uses: actions/checkout@v3
-      - name: Print current directory and github.workspace
-        run: |
-          pwd
-          echo ${{ github.workspace }}
-      - name: Print user information
-        run: whoami
-      - name: Is Conda installed?
-        run: conda info
-      # Miniconda is pre-installed in Ubuntu 20.04 runner
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Miniconda is pre-installed in GitHub-hosted Ubuntu 20.04 runner
       # https://github.com/actions/virtual-environments/blob/ubuntu20/20220330.0/images/linux/Ubuntu2004-Readme.md
       - name: Create Conda environment
         run: conda env create --file environment.yml
-      # Use conda run to run commands in an environment. Each job step runs in a
-      # separate process, so cannot use conda activate to work in an environment
-      - name: Check sphinx-build
-        run: ${{ env.CONDA_RUN }} sphinx-build --version
-      - name: Build the documentation
+
+      - name: Build documentation
         run: ${{ env.CONDA_RUN }} sphinx-build -M html source build
+
       # Uploaded artifacts are dynamically zipped when accessed through GitHub UI
       # so we do not need to zip them beforehand (this would "double zip" the result)
       # https://github.com/marketplace/actions/upload-a-build-artifact#zipped-artifact-downloads
@@ -37,39 +31,39 @@ jobs:
         with:
           name: built-html-docs
           path: build/html/
+
   deploy:
     needs: build
-    # TODO Change to restrict to ACRC:main for actions used in production
+    # TODO Deployment should only happen on main branch of official repository
     # if: >
     #   github.repository == 'ACRC/HPC-community-docs' &&
     #   github.ref == 'refs/heads/main'
-    if: >
-      github.repository == 'jcwomack/HPC-community-docs' &&
-      github.ref == 'refs/heads/prototype/gh-actions'
     runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash
     steps:
-      # actions/checkout required by JamesIves/github-pages-depoy-action
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Get github.repository and github.ref values
-        run: |
-          echo '${{ github.repository}}'
-          echo '${{ github.ref }}'
+
       - name: Download built HTML documentation artifact
         id: download
         uses: actions/download-artifact@v3
         with:
           name: built-html-docs
           path: _built-html-docs
+
+      # A .nojekyll file is required in the root of the publishing source to
+      # prevent GitHub adding an automatic Jekyll build step to deployment
+      # https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages#static-site-generators
       - name: Create .nojekyll
         run: touch ${{ steps.download.outputs.download-path }}/.nojekyll
-      - name: Copy humans.txt for this commit
+
+      # Copy humans.txt directly into the directory to deploy, since this is
+      # linked to as an external URL in the documentation  
+      - name: Copy current humans.txt
         run: cp -v -n humans.txt ${{ steps.download.outputs.download-path }}/
-      - name: Display contents of HTML documentation directory
-        run: ls -R ${{ steps.download.outputs.download-path }}
+      
       - name: Deploy to gh-pages branch
         uses: JamesIves/github-pages-deploy-action@v4.3.0
         with:

--- a/source/index.md
+++ b/source/index.md
@@ -8,7 +8,6 @@ title: "ACRC HPC community documentation"
 %
 % Converted from reStructuredText to MyST Markdown
 
-Temporary modification to force site deployment to GitHub Pages
 ## Introduction
 Welcome to the University of Bristol [Advanced Computing Research Centre (ACRC)][acrc-website] HPC community documentation project!
 Here you will find documentation contributed by HPC users at the University of Bristol, providing domain-specific information on how to effectively use HPC facilities managed by the ACRC at the University of Bristol.

--- a/source/index.md
+++ b/source/index.md
@@ -8,7 +8,7 @@ title: "ACRC HPC community documentation"
 %
 % Converted from reStructuredText to MyST Markdown
 
-
+Temporary modification to force site deployment to GitHub Pages
 ## Introduction
 Welcome to the University of Bristol [Advanced Computing Research Centre (ACRC)][acrc-website] HPC community documentation project!
 Here you will find documentation contributed by HPC users at the University of Bristol, providing domain-specific information on how to effectively use HPC facilities managed by the ACRC at the University of Bristol.

--- a/source/index.md
+++ b/source/index.md
@@ -57,8 +57,8 @@ See [LICENSE.md][acrc-hpc-community-docs-license] in the [GitHub repository][acr
 [acrc-hpc-community-docs-issues]: https://github.com/ACRC/HPC-community-docs/issues "ACRC HPC community documentation GitHub Issues"
 [acrc-hpc-community-docs-prs]: https://github.com/ACRC/HPC-community-docs/pulls "ACRC HPC community documentation GitHub Pull requests"
 [acrc-contact]: https://www.bristol.ac.uk/acrc/contact/ "Contact the ACRC"
-% TODO: Replace with link to file in GitHub Pages
-[humanstxt-file]: https://github.com/ACRC/HPC-community-docs/blob/main/humans.txt "humans.txt"
+% TODO Update humans.txt to production repository URL (when deploying to production repository)
+[humanstxt-file]: https://jcwomack.github.io/HPC-community-docs/humans.txt "humans.txt"
 [humanstxt-website]: https://humanstxt.org "Humans TXT website"
 [cc-by-sa-4]: https://creativecommons.org/licenses/by-sa/4.0/ "CC BY-SA 4.0 license"
 [acrc-hpc-community-docs-license]: https://github.com/ACRC/HPC-community-docs/blob/main/LICENSE.md "ACRC HPC community documentation LICENSE.md"

--- a/source/index.md
+++ b/source/index.md
@@ -8,7 +8,7 @@ title: "ACRC HPC community documentation"
 %
 % Converted from reStructuredText to MyST Markdown
 
-Temporary modification to force site deployment to GitHub Pages (again)
+Temporary modification to force site deployment to GitHub Pages
 ## Introduction
 Welcome to the University of Bristol [Advanced Computing Research Centre (ACRC)][acrc-website] HPC community documentation project!
 Here you will find documentation contributed by HPC users at the University of Bristol, providing domain-specific information on how to effectively use HPC facilities managed by the ACRC at the University of Bristol.

--- a/source/index.md
+++ b/source/index.md
@@ -8,7 +8,7 @@ title: "ACRC HPC community documentation"
 %
 % Converted from reStructuredText to MyST Markdown
 
-Temporary modification to force site deployment to GitHub Pages
+Temporary modification to force site deployment to GitHub Pages (again)
 ## Introduction
 Welcome to the University of Bristol [Advanced Computing Research Centre (ACRC)][acrc-website] HPC community documentation project!
 Here you will find documentation contributed by HPC users at the University of Bristol, providing domain-specific information on how to effectively use HPC facilities managed by the ACRC at the University of Bristol.

--- a/source/index.md
+++ b/source/index.md
@@ -56,8 +56,7 @@ See [LICENSE.md][acrc-hpc-community-docs-license] in the [GitHub repository][acr
 [acrc-hpc-community-docs-issues]: https://github.com/ACRC/HPC-community-docs/issues "ACRC HPC community documentation GitHub Issues"
 [acrc-hpc-community-docs-prs]: https://github.com/ACRC/HPC-community-docs/pulls "ACRC HPC community documentation GitHub Pull requests"
 [acrc-contact]: https://www.bristol.ac.uk/acrc/contact/ "Contact the ACRC"
-% TODO Update humans.txt to production repository URL (when deploying to production repository)
-[humanstxt-file]: https://jcwomack.github.io/HPC-community-docs/humans.txt "humans.txt"
+[humanstxt-file]: https://acrc.github.io/HPC-community-docs/humans.txt "humans.txt"
 [humanstxt-website]: https://humanstxt.org "Humans TXT website"
 [cc-by-sa-4]: https://creativecommons.org/licenses/by-sa/4.0/ "CC BY-SA 4.0 license"
 [acrc-hpc-community-docs-license]: https://github.com/ACRC/HPC-community-docs/blob/main/LICENSE.md "ACRC HPC community documentation LICENSE.md"


### PR DESCRIPTION
The workflow's `build` job installs dependencies in a Conda environment, builds the HTML documentation using `sphinx-build` and uploads an artifact containing the built documentation. This is triggered by the [`push` event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push).

The workflow's `deploy` job downloads the built documentation artifact, makes some minor changes (adding a `.nojekyll` file and copying `humans.txt` into the build directory), and deploys to GitHub Pages using [JamesIves/github-pages-deploy-action](https://github.com/JamesIves/github-pages-deploy-action). This is triggered by the [`push` event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push), but restricted to only run for the `main` branch on the official repository (`ACRC/HPC-community-docs`).

The permissions for `GITHUB_TOKEN` have been restricted to the minimum required for each job (see <https://docs.github.com/en/github-ae@latest/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token> for discussion of `GITHUB_TOKEN` permissions).