### PR TITLE
Custom colours for Sphinx Read The Docs theme

### DIFF
--- a/source/_static/css/customise_theme.css
+++ b/source/_static/css/customise_theme.css
@@ -1,0 +1,18 @@
+/*
+	Use a custom colour (seagreen) for the navigation sidebar/top bar background
+*/
+.wy-side-nav-search {
+	background-color: #2e8b57;
+}
+
+.wy-nav-top {
+	background-color: #2e8b57;
+}
+
+/*
+	Use a custom colour (lightseagreen) for the heading of the contents in the
+	navigation sidebar ("Contents:")
+*/
+.wy-menu-vertical p.caption {
+	color: #20b2aa;
+}

--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -1,0 +1,6 @@
+{% extends "!layout.html" %}
+{# Extend the theme's layout.html (see https://www.sphinx-doc.org/en/master/templating.html) #}
+{% block document %}
+    {{ super() }}
+		Hello, world!
+{% endblock %}

--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -1,6 +1,9 @@
 {% extends "!layout.html" %}
-{# Extend the theme's layout.html (see https://www.sphinx-doc.org/en/master/templating.html) #}
-{% block document %}
-    {{ super() }}
-		Hello, world!
-{% endblock %}
+{# 
+	Extend the theme's layout.html
+	See https://www.sphinx-doc.org/en/master/templating.html 
+#}
+{% block extrahead -%}
+	{{ super() }}
+	<link rel="stylesheet" href="{{ pathto("_static/css/customise_theme.css", 1) }}" type="text/css" />
+{%- endblock extrahead %}


### PR DESCRIPTION
* Add additional CSS file that changes some colours from the default to differentiate this documentation from the [ACRC HPC user documentation](https://www.acrc.bris.ac.uk/protected/hpc-docs/index.html)
  - Changes navigation heading background (when side bar is visible or collapsed) from default blue colour to seagreen
  - Changes "CONTENTS:" sidebar heading text colour from default blue colour to lightseagreen
* The custom CSS file is included in the generated HTML documentation by adding a `layout.html` Jinja templated HTML file to the `source/_templates` directory which extends the theme's `layout.html`

These changes were based on the answer to [this StackOverflow Q&A](https://stackoverflow.com/questions/23211695/modifying-content-width-of-the-sphinx-theme-read-the-docs/33626140#33626140).

The same changes could have been implemented by adding the custom CSS file to the [`html_css_files`](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_css_files) list in `conf.py`. I used the slightly more complicated method which requires extending the `layout.html` template because

* The `layout.html` template is much more flexible in terms of customisability
* The `html_css_files` method is not well-documented
  - It appears that added CSS files should override built-in/theme CSS files, but this information is not clearly stated in [the documentation](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_css_files).