### PR TITLE
Hide example documentation in built documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,6 +202,11 @@ To keep your fork and feature branches up-to-date, it is recommended to regularl
 Keeping the `main` branch in your fork synchronised with the `main` branch in the upstream repository ensures contributions from others to the upstream repository are incorporated into the fork.
 Merging changes from upstream `main` into active feature branches on your fork helps avoid complex merge conflicts arising when creating a pull request.
 
+### Documentation example
+
+An example collection of source files showing the recommended structure of contributed documentation for a research domain and domain-specific software package can be found in [source/example-domain/](source/example-domain/).
+Please feel free to use this example as a starting point for your own contributions.
+
 ## Deployment of the documentation
 
 The HPC community documentation project uses [GitHub Actions][github-docs-actions] to automate building of the documentation into a HTML website and publishing (deployment) of the website.

--- a/source/example-domain/example-software/index.md
+++ b/source/example-domain/example-software/index.md
@@ -2,6 +2,13 @@
 title: "Example Software"
 ---
 
+```{important}
+This is an example which demonstrates the recommended structure of documentation included in the HPC Community Documentation project. 
+The text refers to a fictional research domain "Example domain" and associated software package "Example Software".
+
+If you are authoring documentation to contribute to the HPC Community Documentation project, please feel free to use this example as a starting point.
+```
+
 ```{toctree}
 ---
 hidden: true

--- a/source/example-domain/example-software/index.md
+++ b/source/example-domain/example-software/index.md
@@ -13,7 +13,7 @@ If you are authoring documentation to contribute to the HPC Community Documentat
 ---
 hidden: true
 ---
-job_scripts.md
+job_scripts
 ```
 
 Example Software is available as a module on BlueCrystal and BluePebble and can be loaded into the shell environment using

--- a/source/example-domain/example-software/job_scripts.md
+++ b/source/example-domain/example-software/job_scripts.md
@@ -2,6 +2,13 @@
 title: "Job scripts"
 ---
 
+```{important}
+This is an example which demonstrates the recommended structure of documentation included in the HPC Community Documentation project. 
+The text refers to a fictional research domain "Example domain" and associated software package "Example Software".
+
+If you are authoring documentation to contribute to the HPC Community Documentation project, please feel free to use this example as a starting point.
+```
+
 ## Serial Example Software job
 Small scale Example Software jobs can be run in serial, using a single core.
 Here is an example where Example Software processes the input file `example.in`, producing output `example.out`. 

--- a/source/example-domain/index.md
+++ b/source/example-domain/index.md
@@ -1,6 +1,14 @@
 ---
 title: "Example domain"
+orphan:
 ---
+
+```{important}
+This is an example which demonstrates the recommended structure of documentation included in the HPC Community Documentation project. 
+The text refers to a fictional research domain "Example domain" and associated software package "Example Software".
+
+If you are authoring documentation to contribute to the HPC Community Documentation project, please feel free to use this example as a starting point.
+```
 
 ```{toctree}
 ---

--- a/source/example-domain/index.md
+++ b/source/example-domain/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Example domain"
-orphan:
+orphan: true
 ---
 
 ```{important}

--- a/source/index.md
+++ b/source/index.md
@@ -31,7 +31,6 @@ For general queries related to the ACRC and ACRC HPC facilities, please contact 
 maxdepth: 2
 caption: "Contents:"
 ---
-example-domain/index
 engineering/index
 ```
 


### PR DESCRIPTION
The example documentation in `source/example-domain/` is still built to HTML, but not referenced in any toctree. This means it is not linked to in the documentation contents/navigation sidebar. It can still be found using the search box, or via the full URL for the built HTML files.

I have added a prominent note (admonition) to each example documentation file to indicate that it is an example referring to a fictional research domain and software package.

The example documentation root `source/example-domain/index.md` is marked as `orphan:` in the front-matter [to prevent Sphinx from emitting a warning about it not being included in any toctree](https://www.sphinx-doc.org/en/master/usage/restructuredtext/field-lists.html#special-metadata-fields).