### PR TITLE
Update: abaqus troubleshooting with possible link error

### DIFF
--- a/source/engineering/abaqus/single-node.md
+++ b/source/engineering/abaqus/single-node.md
@@ -55,6 +55,7 @@ will depend on your specific problem. `threads` is recommended and known to work
 
 4. Update the memory per cpu (line 8)
     - Increase this value if you encounter an `oom-kill` or `out-of-memory` error message in your output file
+    - Requesting too little memory (<500M) may cause the compilation or linking of large user subroutines to fail
 
 5. If you are using custom user subroutines:
     - Uncomment either line 12 or line 13 to add the Intel Fortran compiler depending on which system you are running on (BlueCrystal or BluePebble)

--- a/source/engineering/abaqus/troubleshooting.md
+++ b/source/engineering/abaqus/troubleshooting.md
@@ -36,6 +36,21 @@ aborted with system error "Termination signal" (signal 9)
 You can address this issue by increasing the requested `--mem-per-cpu` in your job submission script.
 
 
+## Problem During Linking
+
+The compilation and linking of large complex user subroutines may require much more memory
+than the actual Abaqus job that you intend to run.
+
+If you encounter an error similar to the following:
+
+```text
+ifort: error #10106: Fatal error in ld
+Abaqus Error: Problem during Linking ...
+```
+
+Then you should check that your requested memory limit is not too low (<500M) and try increasing it.
+
+
 ## Node Configuration not Available
 
 ```text


### PR DESCRIPTION
For small Abaqus jobs, the lower limit for requested memory may actually be determined by the compilation and linking of user subroutines rather than the job itself. This PR updates the troubleshooting section to include the error (linker error) that occurs in this scenario.

The troubleshooting section is titled 'Error During Linking' to reflect what the researcher will see in their log file: I'm not aware of any other common linker error that can occur with Abaqus user subroutines, but we can always update this section if any arise.