### PR TITLE
Minor fixes: OpenFOAM documentation and Intro to CLI links

### DIFF
--- a/source/engineering/OpenFOAM/index.md
+++ b/source/engineering/OpenFOAM/index.md
@@ -3,8 +3,7 @@ title: "OpenFOAM"
 ---
 
 The aim of this guide is to provide basic information and example job scripts
-for how to run OpenFOAM on the [University of Bristol HPC systems](https://www.bristol.ac.uk/acrc/high-performance-computing/)
-BlueCrystal Phase 4.
+for how to run OpenFOAM on the [University of Bristol HPC system](https://www.bristol.ac.uk/acrc/high-performance-computing/) BlueCrystal Phase 4.
 
 ```{note}
 The content of this guide is open source, and contributions are welcomed from the OpenFOAM user community!

--- a/source/engineering/OpenFOAM/index.md
+++ b/source/engineering/OpenFOAM/index.md
@@ -44,7 +44,7 @@ $ icoFoam -help
 
 The tutorials in the following link introduce the basic procedures of running OpenFOAM:
 
-- [OpenFOAM tutotrials](https://doc.cfd.direct/openfoam/user-guide-v6/tutorials)
+- [OpenFOAM tutorials](https://doc.cfd.direct/openfoam/user-guide-v6/tutorials)
 
 ```{note}
 Using [ParaView](https://www.paraview.org/) with OpenFOAM on BlueCrystal Phase 4 requires additional setup, which is not covered in this documentation.

--- a/source/engineering/OpenFOAM/index.md
+++ b/source/engineering/OpenFOAM/index.md
@@ -27,7 +27,8 @@ OpenFOAM is available as a module on BlueCrystal Phase 4, and you can search the
 ```console
 $ module avail openfoam
 ```
-To load the module of version 6 into the shell environment use 
+
+To load the module of version 6 into the shell environment use
 
 ```console
 $ module load apps/openfoam/6
@@ -40,7 +41,9 @@ $ icoFoam -help
 ```
 
 ## Get started
+
 The tutorials in the following link introduce the basic procedures of running OpenFOAM:
+
 - [OpenFOAM tutotrials](https://doc.cfd.direct/openfoam/user-guide-v6/tutorials)
 
 ```{note}

--- a/source/engineering/OpenFOAM/index.md
+++ b/source/engineering/OpenFOAM/index.md
@@ -14,7 +14,7 @@ for how to get involved and contribute.
 Some basic familiarity with the Linux command line and remote HPC systems is assumed;
 if you are unfamiliar or need a refresher, then the following courses are recommended:
 
-- [Introduction to the command line](https://alleetanner.github.io/intro_to_CLI/)
+- [Introduction to the command line](https://alleetanner.github.io/intro-to-command-line/)
 - [Introduction to High Performance Computing](https://www.acrc.bris.ac.uk/protected/hpc-docs/training/intro-to-hpc-slurm/index.html)
 
 You may also want to refer to the [official OpenFOAM documentation](http://www.openfoam.org/docs/user).

--- a/source/engineering/OpenFOAM/multi-node.md
+++ b/source/engineering/OpenFOAM/multi-node.md
@@ -4,7 +4,6 @@ title: "Multi-Node Jobs"
 
 Large OpenFOAM jobs can be run across multiple nodes.
 
-
 ## Job Script Template
 
 Here is an example job submission script for a multi-node OpenFOAM job:
@@ -52,4 +51,5 @@ For further information on the structure and syntax of Slurm job scripts, see th
 ```
 
 ### How to use
-Save the script file in the [case folder](https://www.openfoam.com/documentation/user-guide/2-openfoam-cases), `cd` into the case folder, and submit the script to Slurm. The number of MPI processes to request is the number of nodes times the number of tasks per node. 
+
+Save the script file in the [case folder](https://www.openfoam.com/documentation/user-guide/2-openfoam-cases), `cd` into the case folder, and submit the script to Slurm. The number of MPI processes to request is the number of nodes times the number of tasks per node.

--- a/source/engineering/OpenFOAM/multi-node.md
+++ b/source/engineering/OpenFOAM/multi-node.md
@@ -52,4 +52,4 @@ For further information on the structure and syntax of Slurm job scripts, see th
 ```
 
 ### How to use
-Save the script file in the [case folder](https://www.openfoam.com/documentation/user-guide/2-openfoam-cases), `cd` into the case folder, and submit the script to Slurm after the decomposition of mesh and initial field data. The number of MPI processes to request is the number of nodes times the number of tasks per node. 
+Save the script file in the [case folder](https://www.openfoam.com/documentation/user-guide/2-openfoam-cases), `cd` into the case folder, and submit the script to Slurm. The number of MPI processes to request is the number of nodes times the number of tasks per node. 

--- a/source/engineering/OpenFOAM/multi-node.md
+++ b/source/engineering/OpenFOAM/multi-node.md
@@ -14,14 +14,11 @@ Here is an example job submission script for a multi-node OpenFOAM job:
 linenos: true
 ---
 #!/bin/bash
-## Submission script for Cluster
 #SBATCH --job-name=my_job
 #SBATCH --time=0-01:00:00 # hh:mm:ss
 #SBATCH --nodes=4
 #SBATCH --ntasks-per-node=28
 #SBATCH --cpus-per-task=1
-
-
 
 ## system error message output file
 ## leave %j as it's being replaced by JOB ID number
@@ -42,20 +39,17 @@ printf "\n\n\n\n"
 # Load modules required for runtime e.g.
 module load apps/openfoam/6
 
-
-
 # Run the solver. Take pisoFoam with 112 processors for example:
 mpirun -np 112 pisoFoam -parallel 
 
 echo End Time is $(date) 
 echo "Done pisoFoam finish"
 printf "\n\n"
-
 ```
 
 ```{note}
 For further information on the structure and syntax of Slurm job scripts, see the [ACRC HPC documentation pages on job types](https://www.acrc.bris.ac.uk/protected/hpc-docs/job_types/index.html).
 ```
+
 ### How to use
 Save the script file in the [case folder](https://www.openfoam.com/documentation/user-guide/2-openfoam-cases), `cd` into the case folder, and submit the script to Slurm after the decomposition of mesh and initial field data. The number of MPI processes to request is the number of nodes times the number of tasks per node. 
-

--- a/source/engineering/OpenFOAM/multi-node.md
+++ b/source/engineering/OpenFOAM/multi-node.md
@@ -52,4 +52,4 @@ For further information on the structure and syntax of Slurm job scripts, see th
 
 ### How to use
 
-Save the script file in the [case folder](https://www.openfoam.com/documentation/user-guide/2-openfoam-cases), `cd` into the case folder, and submit the script to Slurm. The number of MPI processes to request is the number of nodes times the number of tasks per node.
+Save the script file in the [case folder](https://doc.cfd.direct/openfoam/user-guide-v6/cases), `cd` into the case folder, and submit the script to Slurm. The number of MPI processes to request is the number of nodes times the number of tasks per node.

--- a/source/engineering/OpenFOAM/single-node.md
+++ b/source/engineering/OpenFOAM/single-node.md
@@ -13,14 +13,11 @@ Here is an example job submission script for a single-node OpenFOAM job:
 linenos: true
 ---
 #!/bin/bash
-## Submission script for Cluster
 #SBATCH --job-name=my_job
 #SBATCH --time=0-01:00:00 # hh:mm:ss
 #SBATCH --nodes=1
 #SBATCH --ntasks-per-node=1
 #SBATCH --cpus-per-task=1
-
-
 
 ## system error message output file
 ## leave %j as it's being replaced by JOB ID number
@@ -41,15 +38,12 @@ printf "\n\n\n\n"
 # Load modules required for runtime e.g.
 module load apps/openfoam/6
 
-
 # Run the solver. Take pisoFoam for example:
-
 pisoFoam
 
 echo End Time is $(date) 
 echo "Done pisoFoam finish"
 printf "\n\n"
-
 ```
 
 ```{note}
@@ -58,6 +52,3 @@ For further information on the structure and syntax of Slurm job scripts, see th
 
 ### How to use
 Save the script file in the [case folder](https://www.openfoam.com/documentation/user-guide/2-openfoam-cases), `cd` into the case folder, and submit the script to Slurm.
-
-
-

--- a/source/engineering/OpenFOAM/single-node.md
+++ b/source/engineering/OpenFOAM/single-node.md
@@ -52,4 +52,4 @@ For further information on the structure and syntax of Slurm job scripts, see th
 
 ### How to use
 
-Save the script file in the [case folder](https://www.openfoam.com/documentation/user-guide/2-openfoam-cases), `cd` into the case folder, and submit the script to Slurm.
+Save the script file in the [case folder](https://doc.cfd.direct/openfoam/user-guide-v6/cases), `cd` into the case folder, and submit the script to Slurm.

--- a/source/engineering/OpenFOAM/single-node.md
+++ b/source/engineering/OpenFOAM/single-node.md
@@ -51,4 +51,5 @@ For further information on the structure and syntax of Slurm job scripts, see th
 ```
 
 ### How to use
+
 Save the script file in the [case folder](https://www.openfoam.com/documentation/user-guide/2-openfoam-cases), `cd` into the case folder, and submit the script to Slurm.

--- a/source/engineering/abaqus/index.md
+++ b/source/engineering/abaqus/index.md
@@ -15,7 +15,7 @@ for how to get involved and contribute.
 Some basic familiarity with the Linux command line and remote HPC systems is assumed;
 if you are unfamiliar or need a refresher, then the following courses are recommended:
 
-- [Introduction to the command line](https://altanner.github.io/intro_to_CLI/)
+- [Introduction to the command line](https://alleetanner.github.io/intro-to-command-line/)
 - [Introduction to High Performance Computing](https://www.acrc.bris.ac.uk/protected/hpc-docs/training/intro-to-hpc-slurm/index.html)
 
 ## Setup


### PR DESCRIPTION
Fixes some minor issues in OpenFOAM documentation:

* Fixed several typos
* Removed unneeded line breaks and comment lines
* Removed unclear text

Also fixes issue #18, updating links to @alleetanner's Introduction to the Command Line Interface to use the latest URL.