### PR TITLE
Update abaqus documentation

### DIFF
--- a/source/engineering/abaqus/index.md
+++ b/source/engineering/abaqus/index.md
@@ -21,9 +21,8 @@ if you are unfamiliar or need a refresher, then the following courses are recomm
 ## Setup
 
 ```{important}
-Before using Abaqus at the university, you must first register for an Abaqus license
-[here](https://forms.office.com/pages/responsepage.aspx?id=MH_ksn3NTkql2rGM8aQVG0Ep7WjCs19BiAIhW6hXMWlUREtGTFQwS0sySUtGNzZON1MzR1A5TUJKMS4u).
-Please speak to your supervisor to obtain a charge code for the license.
+Before using Abaqus at the university, you must first register for an Abaqus license -  
+speak to your supervisor for how to do this and to obtain a charge code for the license.
 ```
 
 Abaqus is available as a module on BlueCrystal Phase 4 and BluePebble and can be loaded into the shell environment using
@@ -64,7 +63,7 @@ simultaneously__ as this prevents other users from running Abaqus.
 ```
 
 - You should not be using more than 400 license credits at a time;
-  click [here](http://licmon.fen.bris.ac.uk/licwatch/dsls/index.htm)
+  run the command `abaqus licensing dslsstat -usage` in the command line
   to see how many license credits you are currently using.
 - As a rough guide, limit yourself to a maximum of 8 non-parallel jobs
   or 3 parallel jobs running simultaneously.

--- a/source/engineering/abaqus/index.md
+++ b/source/engineering/abaqus/index.md
@@ -21,7 +21,7 @@ if you are unfamiliar or need a refresher, then the following courses are recomm
 ## Setup
 
 ```{important}
-Before using Abaqus at the university, you must first register for an Abaqus license -  
+Before using Abaqus at the university, you must first register for an Abaqus license -
 speak to your supervisor for how to do this and to obtain a charge code for the license.
 ```
 
@@ -81,7 +81,7 @@ terminated without warning to allow others to use the licenses.
 ```{tip}
 If you are using [Abaci](https://bristolcompositesinstitute.github.io/abaci/index.html)
 to develop and run jobs with user subroutines, you can easily submit HPC jobs
-to SLURM with the
+to Slurm with the
 [`abaci submit` command](https://bristolcompositesinstitute.github.io/abaci/how-to-guides/hpc-job-submission.html). 
 ```
 

--- a/source/engineering/abaqus/index.md
+++ b/source/engineering/abaqus/index.md
@@ -78,6 +78,13 @@ terminated without warning to allow others to use the licenses.
 
 ## Running Jobs
 
+```{tip}
+If you are using [Abaci](https://bristolcompositesinstitute.github.io/abaci/index.html)
+to develop and run jobs with user subroutines, you can easily submit HPC jobs
+to SLURM with the
+[`abaci submit` command](https://bristolcompositesinstitute.github.io/abaci/how-to-guides/hpc-job-submission.html). 
+```
+
 ```{toctree}
 ---
 includehidden: true

--- a/source/engineering/abaqus/multi-node.md
+++ b/source/engineering/abaqus/multi-node.md
@@ -25,6 +25,7 @@ linenos: true
 #SBATCH --cpus-per-task=1 
 #SBATCH --time=0:10:00 
 #SBATCH --mem-per-cpu=4000M
+#SBATCH --account=aero012345
 
 # Load modules 
 module load apps/abaqus/2018

--- a/source/engineering/abaqus/single-node.md
+++ b/source/engineering/abaqus/single-node.md
@@ -59,7 +59,7 @@ will depend on your specific problem. `threads` is recommended and known to work
     - Requesting too little memory (<500M) may cause the compilation or linking of large user subroutines to fail
 
 5. Update the project account (line 9) to match your HPC project code
-    - If you don't know you're HPC project code, you can run the command:
+    - If you don't know your HPC project code, you can run the command:
     
     `sacctmgr show user withassoc format=account where user=$USER`
 

--- a/source/engineering/abaqus/single-node.md
+++ b/source/engineering/abaqus/single-node.md
@@ -20,6 +20,7 @@ linenos: true
 #SBATCH --cpus-per-task=14
 #SBATCH --time=0:10:00 
 #SBATCH --mem-per-cpu=4000M
+#SBATCH --account=aero012345
 
 # Load modules 
 module load apps/abaqus/2018
@@ -57,13 +58,18 @@ will depend on your specific problem. `threads` is recommended and known to work
     - Increase this value if you encounter an `oom-kill` or `out-of-memory` error message in your output file
     - Requesting too little memory (<500M) may cause the compilation or linking of large user subroutines to fail
 
-5. If you are using custom user subroutines:
-    - Uncomment either line 12 or line 13 to add the Intel Fortran compiler depending on which system you are running on (BlueCrystal or BluePebble)
+5. Update the project account (line 9) to match your HPC project code
+    - If you don't know you're HPC project code, you can run the command:
+    
+    `sacctmgr show user withassoc format=account where user=$USER`
+
+6. If you are using custom user subroutines:
+    - Uncomment either line 13 or line 14 to add the Intel Fortran compiler depending on which system you are running on (BlueCrystal or BluePebble)
     - Replace `<usub-file>` on the last line with the name of your Fortran user subroutine source file (_e.g._ `usub_czm.f`)
 
-6. Replace `<job-name>` on the last line with the name of your Abaqus job input file (`.inp`)
+7. Replace `<job-name>` on the last line with the name of your Abaqus job input file (`.inp`)
 
-7. Submit the job to slurm:
+8. Submit the job to slurm:
     - Change directory (`cd`) into the folder containing your job files and job script
     - Run `$ sbatch job.sh` where `job.sh` is the name of your job script
 

--- a/source/engineering/abaqus/troubleshooting.md
+++ b/source/engineering/abaqus/troubleshooting.md
@@ -12,8 +12,8 @@ ERROR 1A000035: License not authorized for this user
 ```
 
 If you receive this error when trying to run Abaqus, then you first need to
-register for a university Abaqus license
-[here](https://forms.office.com/pages/responsepage.aspx?id=MH_ksn3NTkql2rGM8aQVG0Ep7WjCs19BiAIhW6hXMWlUREtGTFQwS0sySUtGNzZON1MzR1A5TUJKMS4u).
+register for a university Abaqus license - speak to your supervisor about
+how to do this.
 
 
 ## Out of Memory


### PR DESCRIPTION
- Fix some old broken links to the registration form
  - Replace with simple text to speak to supervisor about Abaqus registration
- Update the job submission script templates to include the new `--account` field with explanation
- Add short text and link to submitting jobs using Abaci instead

@jcwomack 