### PR TITLE
Abaqus documentation update

### DIFF
--- a/source/engineering/abaqus/index.md
+++ b/source/engineering/abaqus/index.md
@@ -37,21 +37,11 @@ You can verify if Abaqus has been setup correctly by running the following comma
 $ abaqus information=version
 ```
 
-If you are using custom user subroutines, you will also need to load the Intel Fortran compiler:
+If you are using custom user subroutines, you will also need to load the Intel Fortran compiler on BlueCrystal (Phase 4) or BluePebble:
 
-::::{tab-set}
-:::{tab-item} BlueCrystal (Phase 4)
 ```console
-$ module load languages/intel/2020-u4
+$ module load languages/Intel-OneAPI/2022.2.0
 ```
-:::
-
-:::{tab-item} BluePebble
-```console
-$ module load lang/intel-parallel-studio-xe/2020
-```
-:::
-::::
 
 ## Fair Use
 

--- a/source/engineering/abaqus/multi-node.md
+++ b/source/engineering/abaqus/multi-node.md
@@ -29,8 +29,7 @@ linenos: true
 
 # Load modules 
 module load apps/abaqus/2018
-# module load languages/intel/2020-u4              # BlueCrystal (Phase 4)
-# module load lang/intel-parallel-studio-xe/2020   # BluePebble
+module load languages/Intel-OneAPI/2022.2.0              # BlueCrystal (Phase 4) and BluePebble
 
 # Unset SLURM's Global Task ID for ABAQUS's PlatformMPI to work 
 unset SLURM_GTIDS 

--- a/source/engineering/abaqus/single-node.md
+++ b/source/engineering/abaqus/single-node.md
@@ -24,8 +24,7 @@ linenos: true
 
 # Load modules 
 module load apps/abaqus/2018
-# module load languages/intel/2020-u4              # BlueCrystal (Phase 4)
-# module load lang/intel-parallel-studio-xe/2020   # BluePebble
+module load languages/Intel-OneAPI/2022.2.0              # BlueCrystal (Phase 4) and BluePebble
 
 # Unset SLURM's Global Task ID for ABAQUS's PlatformMPI to work 
 unset SLURM_GTIDS 


### PR DESCRIPTION
Hi,

I've updated the Abaqus documentation which now refers to the new Intel compiler module (required for Abaqus + iFort simulations) on the updated BlueCrystal (Phase 4) and BluePebble clusters.

Best,
Alyn